### PR TITLE
Add support for Amazon Redshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ As we work on those, we will be expanding the [Start here](https://github.com/al
 - Clone or dump a full database, including schema and data
 - Create a dump of a MySQL database as XML, restore to Oracle
 - Copy a live NuoDB database directly into in-memory H2
+- Integrate with Amazon Redshift alongside traditional RDBMS engines
 - Run a JUnit test over an in-memory H2 database using a snapshot from a live Oracle environment
 - Automatically run missing upgrades after restoring from a snapshot
 

--- a/morf-redshift/pom.xml
+++ b/morf-redshift/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.alfasoftware</groupId>
+    <artifactId>morf-parent</artifactId>
+    <version>0.1.4-SNAPSHOT</version>
+  </parent>
+
+  <name>Morf - Redshift</name>
+  <description>Morf is a library for cross-platform evolutionary relational database mechanics, database access and database imaging/cloning.</description>
+  <url>https://github.com/alfasoftware/morf</url>
+
+  <artifactId>morf-redshift</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.alfasoftware</groupId>
+      <artifactId>morf-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.alfasoftware</groupId>
+      <artifactId>morf-testsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/morf-redshift/src/main/java/org/alfasoftware/morf/jdbc/redshift/Redshift.java
+++ b/morf-redshift/src/main/java/org/alfasoftware/morf/jdbc/redshift/Redshift.java
@@ -1,0 +1,106 @@
+package org.alfasoftware.morf.jdbc.redshift;
+
+import java.sql.Connection;
+import java.util.Optional;
+import java.util.Stack;
+
+import javax.sql.XADataSource;
+
+import org.alfasoftware.morf.jdbc.AbstractDatabaseType;
+import org.alfasoftware.morf.jdbc.JdbcUrlElements;
+import org.alfasoftware.morf.jdbc.SqlDialect;
+import org.alfasoftware.morf.metadata.Schema;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Support for Redshift database hosts.
+ *
+ * @author Copyright (c) Alfa Financial Software 2019
+ */
+public final class Redshift extends AbstractDatabaseType {
+
+  private static final Log log = LogFactory.getLog(Redshift.class);
+
+  public static final String IDENTIFIER = "REDSHIFT";
+
+  public Redshift() {
+    super("com.amazon.redshift.jdbc.Driver", IDENTIFIER);
+  }
+
+
+  @Override
+  public String formatJdbcUrl(JdbcUrlElements jdbcUrlElements) {
+    return "jdbc:redshift://"
+        + jdbcUrlElements.getHostName()
+        + (jdbcUrlElements.getPort() == 0 ? "" : ":" + jdbcUrlElements.getPort())
+        + "/" + jdbcUrlElements.getDatabaseName()
+        ;
+  }
+
+
+  @Override
+  public Schema openSchema(Connection connection, String databaseName, String schemaName) {
+    return new RedshiftMetaDataProvider(connection, schemaName);
+  }
+
+
+  /**
+   * Returns a Redshift XA data source.
+   *
+   * @throws IllegalStateException If the data source cannot be created.
+   *
+   * @see org.alfasoftware.morf.jdbc.DatabaseType#getXADataSource(String, String, String)
+   */
+  @Override
+  public XADataSource getXADataSource(String jdbcUrl, String username, String password) {
+    try {
+      log.info("Initialising Redshift XA data source...");
+      XADataSource dataSource = (XADataSource) Class.forName("com.amazon.redshift.jdbc.RedshiftXADataSource").newInstance();
+      dataSource.getClass().getMethod("setURL", String.class).invoke(dataSource, jdbcUrl);
+      dataSource.getClass().getMethod("setUser", String.class).invoke(dataSource, username);
+      dataSource.getClass().getMethod("setPassword", String.class).invoke(dataSource, password);
+      return dataSource;
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to create Redshift XA data source", e);
+    }
+  }
+
+
+  @Override
+  public SqlDialect sqlDialect(String schemaName) {
+    return new RedshiftDialect(schemaName);
+  }
+
+
+  @Override
+  public boolean matchesProduct(String product) {
+    return product.equalsIgnoreCase("Redshift");
+  }
+
+
+  @Override
+  public Optional<JdbcUrlElements> extractJdbcUrl(String url) {
+    Stack<String> splitURL = splitJdbcUrl(url);
+
+    String scheme = splitURL.pop();
+
+    if (!scheme.equalsIgnoreCase("redshift")) {
+      return Optional.empty();
+    }
+
+    if (!splitURL.pop().equals("://")) {
+      // If the next characters are not "://" then die
+      throw new IllegalArgumentException("Expected '//' to follow the scheme name in [" + url + "]");
+    }
+
+    JdbcUrlElements.Builder connectionDetails = extractHostAndPort(splitURL);
+
+    // Now get the path
+    String path = extractPath(splitURL);
+
+    connectionDetails.withDatabaseName(path);
+
+    return Optional.of(connectionDetails.build());
+  }
+}

--- a/morf-redshift/src/main/java/org/alfasoftware/morf/jdbc/redshift/RedshiftDialect.java
+++ b/morf-redshift/src/main/java/org/alfasoftware/morf/jdbc/redshift/RedshiftDialect.java
@@ -1,0 +1,19 @@
+package org.alfasoftware.morf.jdbc.redshift;
+
+import org.alfasoftware.morf.jdbc.DatabaseType;
+import org.alfasoftware.morf.jdbc.postgresql.PostgreSQLDialect;
+
+/**
+ * SQL dialect for Amazon Redshift.
+ */
+public class RedshiftDialect extends PostgreSQLDialect {
+
+  public RedshiftDialect(String schemaName) {
+    super(schemaName);
+  }
+
+  @Override
+  public DatabaseType getDatabaseType() {
+    return DatabaseType.Registry.findByIdentifier(Redshift.IDENTIFIER);
+  }
+}

--- a/morf-redshift/src/main/java/org/alfasoftware/morf/jdbc/redshift/RedshiftMetaDataProvider.java
+++ b/morf-redshift/src/main/java/org/alfasoftware/morf/jdbc/redshift/RedshiftMetaDataProvider.java
@@ -1,0 +1,80 @@
+package org.alfasoftware.morf.jdbc.redshift;
+
+import static org.alfasoftware.morf.jdbc.DatabaseMetaDataProviderUtils.getAutoIncrementStartValue;
+import static org.alfasoftware.morf.jdbc.DatabaseMetaDataProviderUtils.getDataTypeFromColumnComment;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Optional;
+
+import org.alfasoftware.morf.jdbc.DatabaseMetaDataProvider;
+import org.alfasoftware.morf.metadata.DataType;
+import org.alfasoftware.morf.metadata.SchemaUtils.ColumnBuilder;
+
+/**
+ * Provides meta data from a Redshift database connection.
+ *
+ * @author Copyright (c) Alfa Financial Software 2019
+ */
+public class RedshiftMetaDataProvider extends DatabaseMetaDataProvider {
+
+  /**
+   * @param connection The database connection from which meta data should be provided.
+   * @param schemaName The name of the schema in which the data is stored.
+   */
+  public RedshiftMetaDataProvider(Connection connection, String schemaName) {
+    super(connection, schemaName);
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.DatabaseMetaDataProvider#isPrimaryKeyIndex(java.lang.String)
+   */
+  @Override
+  protected boolean isPrimaryKeyIndex(String indexName) {
+    return indexName.toLowerCase().endsWith("_pk");
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.DatabaseMetaDataProvider#dataTypeFromSqlType(int, java.lang.String, int)
+   */
+  @Override
+  protected DataType dataTypeFromSqlType(int sqlType, String typeName, int width) {
+    switch (sqlType) {
+      case Types.VARCHAR:
+        if (typeName.equals("text")) {
+          return DataType.CLOB;
+        }
+        return super.dataTypeFromSqlType(sqlType, typeName, width);
+
+      default:
+        return super.dataTypeFromSqlType(sqlType, typeName, width);
+    }
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.DatabaseMetaDataProvider#setAdditionalColumnMetadata(java.lang.String, org.alfasoftware.morf.metadata.SchemaUtils.ColumnBuilder, java.sql.ResultSet)
+   */
+  @Override
+  protected ColumnBuilder setAdditionalColumnMetadata(String tableName, ColumnBuilder columnBuilder, ResultSet columnMetaData) throws SQLException {
+    columnBuilder = super.setAdditionalColumnMetadata(tableName, columnBuilder, columnMetaData);
+
+    // read autonumber from comments
+    if (columnBuilder.isAutoNumbered()) {
+      int startValue = getAutoIncrementStartValue(columnMetaData.getString(REMARKS));
+      columnBuilder = columnBuilder.autoNumbered(startValue == -1 ? 1 : startValue);
+    }
+
+    // read datatype from comments
+    Optional<String> dataTypeComment = getDataTypeFromColumnComment(columnMetaData.getString(REMARKS));
+    if(dataTypeComment.isPresent() && dataTypeComment.get().equals("BIG_INTEGER")){
+      columnBuilder = columnBuilder.dataType(DataType.BIG_INTEGER);
+    }
+
+    return columnBuilder;
+  }
+}

--- a/morf-redshift/src/main/resources/META-INF/services/org.alfasoftware.morf.jdbc.DatabaseType
+++ b/morf-redshift/src/main/resources/META-INF/services/org.alfasoftware.morf.jdbc.DatabaseType
@@ -1,0 +1,1 @@
+org.alfasoftware.morf.jdbc.redshift.Redshift

--- a/morf-redshift/src/test/java/org/alfasoftware/morf/jdbc/redshift/TestRedshiftDatabaseType.java
+++ b/morf-redshift/src/test/java/org/alfasoftware/morf/jdbc/redshift/TestRedshiftDatabaseType.java
@@ -1,0 +1,112 @@
+package org.alfasoftware.morf.jdbc.redshift;
+
+import static org.alfasoftware.morf.jdbc.DatabaseTypeIdentifierTestUtils.mockDataSourceFor;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+import java.sql.SQLException;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.alfasoftware.morf.jdbc.DatabaseType;
+import org.alfasoftware.morf.jdbc.DatabaseTypeIdentifier;
+import org.alfasoftware.morf.jdbc.JdbcUrlElements;
+import org.alfasoftware.morf.jdbc.JdbcUrlElements.Builder;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for DatabaseType.REDSHIFT
+ *
+ * @author Copyright (c) Alfa Financial Software 2019
+ */
+public class TestRedshiftDatabaseType {
+
+  private DatabaseType databaseType;
+
+  @Before
+  public void setup() {
+    databaseType = DatabaseType.Registry.findByIdentifier(Redshift.IDENTIFIER);
+  }
+
+
+  /**
+   * Test the JDBC URL construction.
+   */
+  @Test
+  public void testFormatJdbcUrl() {
+    assertEquals("jdbc:redshift://foo.com:123/alfa", databaseType.formatJdbcUrl(jdbcUrlElementBuilder().withHost("foo.com").withPort(123).withDatabaseName("alfa").build()));
+    assertEquals("jdbc:redshift://foo.com/alfa", databaseType.formatJdbcUrl(jdbcUrlElementBuilder().withHost("foo.com").withDatabaseName("alfa").build()));
+    assertEquals("jdbc:redshift://localhost/data", databaseType.formatJdbcUrl(jdbcUrlElementBuilder().withHost("localhost").withDatabaseName("data").build()));
+  }
+
+
+  /**
+   * Tests Redshift formatted JDBC URLs.
+   */
+  @Test
+  public void testBuildConnectionDetailsFromMySQL() {
+    JdbcUrlElements result = databaseType.extractJdbcUrl("jdbc:redshift://localhost:3306/alfa").get();
+
+    assertEquals("Should have the correct type", Redshift.IDENTIFIER, result.getDatabaseType());
+    assertEquals("Should have the correct host", "localhost", result.getHostName());
+    assertEquals("Should have the correct port", 3306, result.getPort());
+    assertEquals("Should have the correct database name", "alfa", result.getDatabaseName());
+  }
+
+
+  /**
+   * Tests Redshift formatted JDBC URLs.
+   */
+  @Test
+  public void testBuildConnectionDetailsFromMySQLNoPort() {
+    JdbcUrlElements result = databaseType.extractJdbcUrl("jdbc:redshift://localhost/alfa").get();
+
+    assertEquals("Should have the correct type", Redshift.IDENTIFIER, result.getDatabaseType());
+    assertEquals("Should have the correct host", "localhost", result.getHostName());
+    assertEquals("Should have the correct database name", "alfa", result.getDatabaseName());
+  }
+
+
+  /**
+   * Checks the bidirectionality of our URL split and combine behaviour.
+   */
+  @Test
+  public void testUrlRoundTrips() {
+    comparerUrlRoundtrips(JdbcUrlElements.forDatabaseType(Redshift.IDENTIFIER).withHost("hostname").withPort(3306).withDatabaseName("databasename").build());
+    comparerUrlRoundtrips(JdbcUrlElements.forDatabaseType(Redshift.IDENTIFIER).withHost("hostname").withDatabaseName("databasename").build());
+  }
+
+
+  /**
+   * Tests a URL <- split -> URL round-trip.
+   */
+  private void comparerUrlRoundtrips(JdbcUrlElements jdbcUrlElements) {
+    String jdbcURL = databaseType.formatJdbcUrl(jdbcUrlElements);
+    JdbcUrlElements cd = databaseType.extractJdbcUrl(jdbcURL).get();
+    assertEquals(jdbcUrlElements, cd);
+  }
+
+
+  /**
+   * Test identification of a database platform.
+   */
+  @Test
+  public void testIdentifyFromMetaData() throws SQLException {
+    // -- Unknown and resource management...
+    //
+    DataSource dataSource = mockDataSourceFor("FictiousDB", "9.9.9", 9, 9);
+    assertEquals(Optional.empty(), new DatabaseTypeIdentifier(dataSource).identifyFromMetaData());
+    verify(dataSource.getConnection()).close();
+
+    // -- Support platforms...
+    //
+    assertEquals(databaseType, new DatabaseTypeIdentifier(mockDataSourceFor("Redshift", "1.3.167", 1, 3)).identifyFromMetaData().get());
+  }
+
+
+  private Builder jdbcUrlElementBuilder() {
+    return JdbcUrlElements.forDatabaseType(Redshift.IDENTIFIER);
+  }
+}

--- a/morf-redshift/src/test/java/org/alfasoftware/morf/jdbc/redshift/TestRedshiftDialect.java
+++ b/morf-redshift/src/test/java/org/alfasoftware/morf/jdbc/redshift/TestRedshiftDialect.java
@@ -1,0 +1,16 @@
+package org.alfasoftware.morf.jdbc.redshift;
+
+import org.alfasoftware.morf.jdbc.SqlDialect;
+import org.alfasoftware.morf.jdbc.postgresql.TestPostgreSQLDialect;
+
+import org.alfasoftware.morf.jdbc.redshift.RedshiftDialect;
+/**
+ * Runs PostgreSQL dialect tests using the Redshift dialect implementation.
+ */
+public class TestRedshiftDialect extends TestPostgreSQLDialect {
+
+  @Override
+  protected SqlDialect createTestDialect() {
+    return new RedshiftDialect("testschema");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <module>morf-nuodb</module>
     <module>morf-oracle</module>
     <module>morf-postgresql</module>
+    <module>morf-redshift</module>
     <module>morf-sqlserver</module>
     <module>morf-integration-test</module>
   </modules>
@@ -225,6 +226,11 @@
       <dependency>
         <groupId>org.alfasoftware</groupId>
         <artifactId>morf-postgresql</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.alfasoftware</groupId>
+        <artifactId>morf-redshift</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
## Summary
- introduce `morf-redshift` module with dialect, metadata provider and database type
- register Redshift via service loader
- reuse PostgreSQL dialect tests for Redshift and add database type tests
- document Redshift support in README
- include module in parent POM and dependency management

## Testing
- `mvn -q test -pl morf-redshift` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403b04660083309bb967c3fdc34503